### PR TITLE
Use shred instead of rm to remove sensitive data from disk

### DIFF
--- a/content/post/set-up-gpg/index.md
+++ b/content/post/set-up-gpg/index.md
@@ -406,7 +406,7 @@ Approve the prompts and your primary private key will be deleted from GPG.
 Clean up the private key files by running the following command from your working directory.
 
 ```sh
-rm ./*-private.gpg
+shred -uzv ./*-private.gpg
 ```
 
 Everything is cleaned up and backed up. GPG is fully configured and ready for you to start using.


### PR DESCRIPTION
`rm` will not delete file contents from disk, but actually "unlink" them, i.e., removing the inode entry in the filesystem. This is pretty much irreversible but insecure because user data may remain for a long time in the disk until it is overwritten by another file. 

`shred` will write random data in the files and try to commit it to disk. The chosen flags also add a final pass writing all zeros, zeroing the filename and then removing the file entry.

PS: thanks for the excellent post.